### PR TITLE
Add Github workflow to run tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,12 @@
+name: Continuous Integration Tests
+on: [push]
+jobs:
+  check-bats-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: '14'
+      - run: npm install
+      - run: npm run test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,5 +3,8 @@ version: "3.7"
 services:
   web:
     build: .
+    command: node build && node start
+    volumes:
+      - ".:/usr/src/app"
     ports:
       - "5000:5000"

--- a/src/issuer.spec.ts
+++ b/src/issuer.spec.ts
@@ -45,5 +45,5 @@ describe('Issuer test',
       };
       const result = await sign(credential, options);
       expect(result.issuer).to.equal(controller);
-    }).timeout(10000);
+    }).slow(5000).timeout(10000);
   });


### PR DESCRIPTION
Part of https://github.com/digitalcredentials/sign-and-verify/issues/1

This adds a github actions workflow so commits will be verified with tests passing. You should see the run actions on the "Checks" tab of this PR.

It also fixes some edge cases around `docker-compose run web bash` contexts.