### PR TITLE
Verifiable Presentations and other clean up

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,21 @@ npm run start
 
 
 ```
-curl --header "Content-Type: application/json" --request POST --data '{"@context":["https://www.w3.org/2018/credentials/v1","https://www.w3.org/2018/credentials/examples/v1"],"id":"http://example.gov/credentials/3732","type":["VerifiableCredential","UniversityDegreeCredential"],"issuer":"did:elem:ropsten:EiBJJPdo-ONF0jxqt8mZYEj9Z7FbdC87m2xvN0_HAbcoEg","issuanceDate":"2020-03-10T04:24:12.164Z","credentialSubject":{"id":"did:elem:ropsten:EiBJJPdo-ONF0jxqt8mZYEj9Z7FbdC87m2xvN0_HAbcoEg","degree":{"type":"BachelorDegree","name":"Bachelor of Science and Arts"}}}' http://127.0.0.1:5000/issue/credentials
+curl --header "Content-Type: application/json" --request POST --data '{"credential": {"@context":["https://www.w3.org/2018/credentials/v1","https://www.w3.org/2018/credentials/examples/v1"],"id":"http://example.gov/credentials/3732","type":["VerifiableCredential","UniversityDegreeCredential"],"issuer":"did:web:digitalcredentials.github.io","issuanceDate":"2020-03-10T04:24:12.164Z","credentialSubject":{"id":"did:elem:ropsten:EiBJJPdo-ONF0jxqt8mZYEj9Z7FbdC87m2xvN0_HAbcoEg","degree":{"type":"BachelorDegree","name":"Bachelor of Science and Arts"}}}, "options": {"verificationMethod": "did:web:digitalcredentials.github.io#96K4BSIWAkhcclKssb8yTWMQSz4QzPWBy-JsAFlwoIs"}}' http://127.0.0.1:5000/issue/credentials
 ```
 
-### Verify
+### Verify Credential
 
 ```
-curl --header "Content-Type: application/json" --request POST --data '{"@context":["https://www.w3.org/2018/credentials/v1","https://www.w3.org/2018/credentials/examples/v1"],"id":"http://example.gov/credentials/3732","type":["VerifiableCredential","UniversityDegreeCredential"],"issuer":"did:web:digitalcredentials.github.io","issuanceDate":"2020-03-10T04:24:12.164Z","credentialSubject":{"id":"did:elem:ropsten:EiBJJPdo-ONF0jxqt8mZYEj9Z7FbdC87m2xvN0_HAbcoEg","degree":{"type":"BachelorDegree","name":"Bachelor of Science and Arts"}},"proof":{"type":"/JsonWebSignature2020","dct:created":{"type":"xsd:dateTime","@value":"2020-08-07T17:20:15.221Z"},"https://w3id.org/security#jws":"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..mEj26Gk-k8nMD0Bq6wE7GwFk6q_6C-PZMSFdGYe4CDGcnmIBTRXtSi7EN-2jHhAAJLfDOAaEHu9ZrtVhxsaDBw","https://w3id.org/security#proofPurpose":{"id":"https://w3id.org/security#assertionMethod"},"https://w3id.org/security#verificationMethod":{"id":"did:web:digitalcredentials.github.io#96K4BSIWAkhcclKssb8yTWMQSz4QzPWBy-JsAFlwoIs"}}}' http://127.0.0.1:5000/verify/credentials
+curl --header "Content-Type: application/json" --request POST --data '{"verifiableCredential": {"@context":["https://www.w3.org/2018/credentials/v1","https://www.w3.org/2018/credentials/examples/v1"],"id":"http://example.gov/credentials/3732","type":["VerifiableCredential","UniversityDegreeCredential"],"issuer":"did:web:digitalcredentials.github.io","issuanceDate":"2020-03-10T04:24:12.164Z","credentialSubject":{"id":"did:elem:ropsten:EiBJJPdo-ONF0jxqt8mZYEj9Z7FbdC87m2xvN0_HAbcoEg","degree":{"type":"BachelorDegree","name":"Bachelor of Science and Arts"}},"proof":{"type":"/JsonWebSignature2020","dct:created":{"type":"xsd:dateTime","@value":"2020-10-12T16:59:13.588Z"},"https://w3id.org/security#jws":"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..uEcrIAdPZfUdsP3uQmq-LE0PuSLlvXQLPpZiuH7JXss7phCOEHzw8z1MgG6Bf5J3AxYXmrkzPHkr2iUi-TVaBg","https://w3id.org/security#proofPurpose":{"id":"https://w3id.org/security#assertionMethod"},"https://w3id.org/security#verificationMethod":{"id":"did:web:digitalcredentials.github.io#96K4BSIWAkhcclKssb8yTWMQSz4QzPWBy-JsAFlwoIs"}}}, "options": {"verificationMethod": "did:web:digitalcredentials.github.io#96K4BSIWAkhcclKssb8yTWMQSz4QzPWBy-JsAFlwoIs"}}' http://127.0.0.1:5000/verify/credentials
 ```
+
+### Verify Presentation
+
+```
+curl --header "Content-Type: application/json" --request POST --data '{"verifiablePresentation": {"@context":["https://www.w3.org/2018/credentials/v1"],"type":["VerifiablePresentation"],"id":"456","holder":"did:web:digitalcredentials.github.io","proof":{"type":"/JsonWebSignature2020","http://purl.org/dc/terms/created":{"type":"http://www.w3.org/2001/XMLSchema#dateTime","@value":"2020-10-12T17:06:49.767Z"},"https://w3id.org/security#challenge":"123","https://w3id.org/security#jws":"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..4OiWb5EGPmXhtMNhmVXwyYhUI2BLbgcP0o-GNQaXBsMARfEGMTZi28BDiXmkdsCWvx2xmFD-cROvyIr-qMpeCQ","https://w3id.org/security#proofPurpose":{"id":"https://w3id.org/security#authenticationMethod"},"https://w3id.org/security#verificationMethod":{"id":"did:web:digitalcredentials.github.io#96K4BSIWAkhcclKssb8yTWMQSz4QzPWBy-JsAFlwoIs"}}}, "options": {"verificationMethod": "did:web:digitalcredentials.github.io#96K4BSIWAkhcclKssb8yTWMQSz4QzPWBy-JsAFlwoIs", "challenge":"123"}}' http://127.0.0.1:5000/verify/presentations
+```
+
 
 ### Request
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -523,8 +523,7 @@
     "dotenv": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
-      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
-      "dev": true
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
     },
     "ecc-jsbn": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@transmute/json-web-key-2020": "^1.0.0",
     "@transmute/json-web-signature-2020": "^1.0.0",
+    "dotenv": "^8.2.0",
     "fastify": "^3.2.0",
     "fastify-cors": "^4.1.0",
     "fastify-swagger": "^3.4.0",
@@ -31,7 +32,6 @@
     "@types/sinon": "^9.0.8",
     "chai": "^4.2.0",
     "copyfiles": "^2.4.0",
-    "dotenv": "^8.2.0",
     "fastify-log": "^1.2.1",
     "mocha": "^8.1.1",
     "sinon": "^9.1.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ server.post(
     const credential = request.body;
     //const options = requestBody['options'];
     const options = {
-      assertionMethod: 'did:web:digitalcredentials.github.io#96K4BSIWAkhcclKssb8yTWMQSz4QzPWBy-JsAFlwoIs'
+      verificationMethod: 'did:web:digitalcredentials.github.io#96K4BSIWAkhcclKssb8yTWMQSz4QzPWBy-JsAFlwoIs'
     };
 
     const result = await sign(credential, options);
@@ -58,7 +58,7 @@ server.post(
     const credential = request.body;
     //const options = requestBody['options'];
     const options = {
-      assertionMethod: 'did:web:digitalcredentials.github.io#96K4BSIWAkhcclKssb8yTWMQSz4QzPWBy-JsAFlwoIs'
+      verificationMethod: 'did:web:digitalcredentials.github.io#96K4BSIWAkhcclKssb8yTWMQSz4QzPWBy-JsAFlwoIs'
     };
 
     const result = await verify(credential, options);

--- a/src/issuer.spec.ts
+++ b/src/issuer.spec.ts
@@ -49,7 +49,7 @@ describe('Issuer test',
 
     it('should sign', async () => {
       const options = {
-        'assertionMethod': identifer
+        'verificationMethod': identifer
       };
       const result = await issuer.sign(credential, options);
       expect(result.issuer).to.equal(controller);
@@ -57,7 +57,7 @@ describe('Issuer test',
 
     it('should verify', async () => {
       const options = {
-        'assertionMethod': identifer
+        'verificationMethod': identifer
       };
 
       const temp = await issuer.sign(credential, options);

--- a/src/issuer.spec.ts
+++ b/src/issuer.spec.ts
@@ -7,6 +7,8 @@ import { Config } from './config';
 
 const identifer = 'did:web:digitalcredentials.github.io#96K4BSIWAkhcclKssb8yTWMQSz4QzPWBy-JsAFlwoIs';
 const controller = 'did:web:digitalcredentials.github.io';
+const challenge = '123';
+const presentationId = '456'
 const credential = {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
@@ -27,6 +29,33 @@ const credential = {
     }
   }
 };
+const verifiablePresentation =
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1"
+  ],
+  "type": [
+    "VerifiablePresentation"
+  ],
+  "id": "456",
+  "holder": "did:web:digitalcredentials.github.io",
+  "proof": {
+    "type": "/JsonWebSignature2020",
+    "http://purl.org/dc/terms/created": {
+      "type": "http://www.w3.org/2001/XMLSchema#dateTime",
+      "@value": "2020-10-12T17:23:38.912Z"
+    },
+    "https://w3id.org/security#challenge": "123",
+    "https://w3id.org/security#jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..YKyqSBDjkmYEdgTuUJaylwfI9z8XjHP7eJ7W9fRoywgSIgUncWWRi6QtGYuHXth11sEpHneuIh0aPFCeqV4DBw",
+    "https://w3id.org/security#proofPurpose": {
+      "id": "https://w3id.org/security#authenticationMethod"
+    },
+    "https://w3id.org/security#verificationMethod": {
+      "id": "did:web:digitalcredentials.github.io#96K4BSIWAkhcclKssb8yTWMQSz4QzPWBy-JsAFlwoIs"
+    }
+  }
+};
+
 const config: Config = {
   port: 5000,
   unlockedDid: JSON.parse(readFileSync("data/unlocked-did:web:digitalcredentials.github.io.json").toString("ascii"))
@@ -69,9 +98,9 @@ describe('Issuer test',
     it('should sign presentation', async () => {
       const options = {
         'verificationMethod': identifer,
-        'challenge': '123'
+        'challenge': challenge
       };
-      const result = await issuer.createAndSignPresentation({}, options);
+      const result = await issuer.createAndSignPresentation(null, presentationId, controller, options);
       expect(result.proof['https://w3id.org/security#verificationMethod']['id']).to.equal(identifer);
     }).slow(5000).timeout(10000);
 
@@ -79,10 +108,9 @@ describe('Issuer test',
     it('should verify presentation', async () => {
       const options = {
         'verificationMethod': identifer,
-        'challenge': '123'
+        'challenge': challenge
       };
-      const result = await issuer.createAndSignPresentation({}, options);
-      const verificationResult = await issuer.verifyPresentation(result, options);
+      const verificationResult = await issuer.verifyPresentation(verifiablePresentation, options);
       expect(verificationResult.verified).to.equal(true);
     }).slow(5000).timeout(10000);
   });

--- a/src/issuer.spec.ts
+++ b/src/issuer.spec.ts
@@ -64,4 +64,25 @@ describe('Issuer test',
       const verificationResult = await issuer.verify(temp, options);
       expect(verificationResult.verified).to.equal(true);
     }).slow(5000).timeout(10000);
+
+
+    it('should sign presentation', async () => {
+      const options = {
+        'verificationMethod': identifer,
+        'challenge': '123'
+      };
+      const result = await issuer.createAndSignPresentation({}, options);
+      expect(result.proof['https://w3id.org/security#verificationMethod']['id']).to.equal(identifer);
+    }).slow(5000).timeout(10000);
+
+
+    it('should verify presentation', async () => {
+      const options = {
+        'verificationMethod': identifer,
+        'challenge': '123'
+      };
+      const result = await issuer.createAndSignPresentation({}, options);
+      const verificationResult = await issuer.verifyPresentation(result, options);
+      expect(verificationResult.verified).to.equal(true);
+    }).slow(5000).timeout(10000);
   });

--- a/src/request.ts
+++ b/src/request.ts
@@ -24,7 +24,7 @@ export async function requestCredential(requestInfo: any) {
   copy.credentialSubject.id = requestInfo.subjectDid;
 
   const options = {
-    assertionMethod: 'did:web:digitalcredentials.github.io#96K4BSIWAkhcclKssb8yTWMQSz4QzPWBy-JsAFlwoIs'
+    verificationMethod: 'did:web:digitalcredentials.github.io#96K4BSIWAkhcclKssb8yTWMQSz4QzPWBy-JsAFlwoIs'
   };
 
   return issuer.sign(copy, options);

--- a/src/signatures.spec.ts
+++ b/src/signatures.spec.ts
@@ -1,0 +1,40 @@
+import { expect } from 'chai';
+import 'mocha';
+
+import { SignatureOptions, getSigningDate, getSigningKeyIdentifier, DefaultProofPurpose } from "./signatures";
+
+describe("signatures", () => {
+
+  describe("SignatureOptions", () => {
+    it("should get default proof purpose", () => {
+      const options = new SignatureOptions({});
+      expect(options.proofPurpose!).to.equal(DefaultProofPurpose);
+    });
+
+    it("should parse proof purpose", () => {
+      const proofPurpose = 'someProofPurpose';
+
+      const options = new SignatureOptions({ proofPurpose: proofPurpose });
+      expect(options.proofPurpose!).to.equal(proofPurpose);
+    });
+  });
+
+  it("should get signing key id", () => {
+    const signingKeyIdentifier = 'did:example:123#abc';
+
+    const options = new SignatureOptions({ verificationMethod: signingKeyIdentifier });
+    const id = getSigningKeyIdentifier(options);
+    expect(id).to.equal(signingKeyIdentifier);
+  });
+
+  it("should get signing date", () => {
+    const signingKeyIdentifier = 'did:example:123#abc';
+    const created = '2020-10-12T16:35:18.531Z'
+
+    const options = new SignatureOptions({ proofPurpose: 'someMethod', verificationMethod: signingKeyIdentifier, created: created });
+    const signingDate = getSigningDate(options);
+    expect(signingDate).to.equal(created);
+  });
+});
+
+

--- a/src/signatures.ts
+++ b/src/signatures.ts
@@ -1,6 +1,8 @@
+export const DefaultProofPurpose = 'assertionMethod';
+
 export class SignatureOptions {
   public verificationMethod?: string;
-  public proofPurpose?: string = "assertionMethod";
+  public proofPurpose?: string = DefaultProofPurpose;
   public created?: string;
   public domain?: string;
   public challenge?: string;

--- a/src/signatures.ts
+++ b/src/signatures.ts
@@ -1,0 +1,22 @@
+export class SignatureOptions {
+  public verificationMethod?: string;
+  public proofPurpose?: string = "assertionMethod";
+  public created?: string;
+  public domain?: string;
+  public challenge?: string;
+
+  public constructor(options: SignatureOptions) {
+    Object.assign(this, options);
+  }
+}
+
+// Added to work around confusing naming schemes. Later, there may be some layer of indirection
+// but for now, it's just the verificationMethod for our use cases.
+export function getSigningKeyIdentifier(options: SignatureOptions): string {
+  return options.verificationMethod!;
+};
+
+export function getSigningDate(options: SignatureOptions): string {
+  // TODO: double-check this is how it's being used
+  return options.created ? options.created! : new Date().toISOString()
+};


### PR DESCRIPTION
This addresses #4 and includes some other cleanup.

Changes:
- Noticed endpoints were not consistent with [vc-http-api](https://w3c-ccg.github.io/vc-http-api) definitions. We eventually need a full audit, tracked separately in #12 
- Factored out `SignatureOptions` to match vc-http-api definition; attempted to improve code readability there. The vc-http-api is confusing in some areas (terminology and apparent redundant parameters in options). I'll track that against the vc-http-api spec
- Updated README.md to reflect updated API calls (above)
- Support sign/verify VPs. Per vc-http-api, the verify VP endpoint is exposed via rest API but not the sign VP endpoint. That's consistent with our expected usage -- sign VP will be used as a library in the wallet. Our issuer needs verify VP to ensure the learner controls the DID.

There are remaining awkward bits, which #6 should help address.

Note: based on kh_swagger branch
