### PR TITLE
Reducing image size by using the slim base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.11
+FROM node:14.14-stretch-slim
 
 WORKDIR /usr/src/app
 
@@ -12,5 +12,4 @@ RUN npm run build
 
 EXPOSE 5000
 
-USER node
-CMD node dist/index.js
+CMD ["node", "dist/index.js"]


### PR DESCRIPTION
- Changed the base image to use the slim variant, reducing the resultant image size by ~800 MB
- Removed extraneous `USER` directive as that is already specified in the base image
- Added port 80 as an exposed port for using in Fargate