### PR TITLE
Add git to docker container during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,10 @@ ADD package.json package-lock.json ./
 # Install OS dependencies, install Node packages, and purge OS packages in one step
 # to reduce the size of the resulting image.
 RUN apt-get update && \
-    apt-get install -y python3-minimal build-essential && \
+    apt-get install -y python3-minimal build-essential git && \
     npm install && \
     apt-get clean && \
-    apt-get purge -y python3-minimal build-essential && \
+    apt-get purge -y python3-minimal build-essential git && \
     apt-get -y autoremove
 
 COPY . /usr/src/app


### PR DESCRIPTION
Adds `git` to the docker container so `npm install` passes.

Checkout the code and `docker build .`, it should succeed.