### PR TITLE
Fix docker build with git-based dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ WORKDIR /usr/src/app
 
 ADD package.json package-lock.json ./
 
+# FIXME: temporary workaround because of git-based dependencies
+RUN npm install -g rollup
+
 # Install OS dependencies, install Node packages, and purge OS packages in one step
 # to reduce the size of the resulting image.
 RUN apt-get update && \


### PR DESCRIPTION
Run

`docker build . -t sav`
`docker run --rm -it sav`

It should get at least far enough to fail on an environment variable we're not passing